### PR TITLE
Use kebab-case in test function names

### DIFF
--- a/t/balances.t
+++ b/t/balances.t
@@ -5,7 +5,7 @@ use WebService::Justcoin;
 plan 10;
 
 my $j := WebService::Justcoin.new(:url-get(sub ($) { }));
-dies_ok { $j.balances() }, "method requires API key";
+dies-ok { $j.balances() }, "method requires API key";
 
 $j := WebService::Justcoin.new(
         :api-key("wow-so-nice-key"),

--- a/t/orders.t
+++ b/t/orders.t
@@ -5,7 +5,7 @@ use WebService::Justcoin;
 plan 17;
 
 my $j := WebService::Justcoin.new(:url-get(sub ($) { }));
-dies_ok { $j.orders() }, "method requires API key";
+dies-ok { $j.orders() }, "method requires API key";
 
 # no orders in book
 {
@@ -48,7 +48,7 @@ dies_ok { $j.orders() }, "method requires API key";
     my $res = $j.create-order(:market("BTCNOK"), :type("bid"), :price(10.0), :amount(0.01));
     ok $res{'id'}:exists, "got id back";
 
-    dies_ok { $j.create-order(:market("BTCNOK", :type("invalid"), :price(10000), :amount(1.0))) }, "invalid type";
+    dies-ok { $j.create-order(:market("BTCNOK", :type("invalid"), :price(10000), :amount(1.0))) }, "invalid type";
 
     # market price
     $res = $j.create-order(:market("BTCNOK"), :type("ask"), :amount(0.1));
@@ -60,7 +60,7 @@ dies_ok { $j.orders() }, "method requires API key";
     $j := WebService::Justcoin.new(
         :api-key("some-nice-key"),
         :url-delete(sub ($) { }));
-    lives_ok { $j.cancel-order(1234); }, "lives running cancel-order";
+    lives-ok { $j.cancel-order(1234); }, "lives running cancel-order";
 }
 
 sub no-orders-response { "[ ]" }


### PR DESCRIPTION
Test function names with underscores have been deprecated in favour of their
kebab-case variants.  The deprecated form will be removed in Rakudo 2015.09.
This change brings the test suite up to date with current Rakudo.
