### PR TITLE
Bind to hashes instead of assigning

### DIFF
--- a/t/balances.t
+++ b/t/balances.t
@@ -20,7 +20,7 @@ ok $b{'hold'}:exists, "has hold";
 ok $b{'available'}:exists, "available";
 
 { # currency provided
-    my %btc = $j.balances(currency => "BTC");
+    my %btc := $j.balances(currency => "BTC");
     ok %btc{'currency'}:exists, "has currency";
     ok %btc{'balance'}:exists, "has balance";
     ok %btc{'hold'}:exists, "has hold";

--- a/t/market.t
+++ b/t/market.t
@@ -29,7 +29,7 @@ plan 20;
     my $j := WebService::Justcoin.new(
             :url-get(sub ($url) { response_markets() }));
 
-    my %market = $j.markets(:id("BTCNOK"));
+    my %market := $j.markets(:id("BTCNOK"));
     is %market{"id"}, "BTCNOK", "Fetched BTCNOK market";
 
     %market = $j.markets(:id("Does not exist"));
@@ -40,7 +40,7 @@ plan 20;
 {
     my $j := WebService::Justcoin.new(
             :url-get(sub ($url) { response-depth() }));
-    my %depth = $j.market-depth("BTCNOK");
+    my %depth := $j.market-depth("BTCNOK");
     ok %depth{'bids'}:exists, "has bids in response";
     ok %depth{'asks'}:exists, "has asks in response";
 
@@ -50,7 +50,7 @@ plan 20;
     # empty order book
     $j := WebService::Justcoin.new(
             :url-get(sub ($url) { response-no-depth() }));
-    %depth = $j.market-depth("NON-EXISTING-MARKET");
+    %depth := $j.market-depth("NON-EXISTING-MARKET");
     ok %depth{'bids'}:exists, "has bids in response";
     ok %depth{'asks'}:exists, "has asks in response";
 

--- a/t/withdraws.t
+++ b/t/withdraws.t
@@ -9,7 +9,7 @@ plan 12;
         :api-key("neat-key"),
         :url-post(sub ($, %) { create-withdraw-response() }));
 
-    my %resp = $j.create-withdraw-btc(
+    my %resp := $j.create-withdraw-btc(
             address => "1Q9nM6xrPdTk59JwWhWfuygWRxa1bXJW8g",
             amount => 0.01);
 


### PR DESCRIPTION
Several assignments to hash variables require using bind (:=) instead of
assignment (=) so as to avoid itemized hash deprecation warnings.  The
deprecated behaviour will be removed in Rakudo 2015.07.  This change brings
the code up to date with the current version of Rakudo.
